### PR TITLE
Update fn_init.sqf

### DIFF
--- a/AdminMenuDocs/UG_AM/fn_init.sqf
+++ b/AdminMenuDocs/UG_AM/fn_init.sqf
@@ -1,1 +1,1 @@
-execvm "compiles.sqf";
+execvm "\UG_AM\Compiles.sqf";


### PR DESCRIPTION
\UG_AM\ is needed to actually load Compiles.sqf since it's in a packed addon.
